### PR TITLE
Update ocserv-genkey

### DIFF
--- a/files/ocserv-genkey
+++ b/files/ocserv-genkey
@@ -1,9 +1,25 @@
 #!/bin/sh
+#default key type:rsa
+KEY_TYPE="rsa"
+
+#check key type 'rsa', 'rsa-pss', 'dsa', 'ecdsa', 'ed25519, 'ed448', 'x25519', and 'x448'
+if [ $# -gt 0 ]; then
+    case "$1" in
+        rsa|rsa-pss|dsa|ecdsa|ed25519|ed448|x25519|x448)
+            KEY_TYPE="$1"
+            ;;
+        *)
+            echo "Usage: $0 [rsa|rsa-pss|dsa|ecdsa|ed25519|ed448|x25519|x448]"
+            echo "Default key type: rsa"
+            exit 1
+            ;;
+    esac
+fi
 
 #generate CA certificate/key
 if test ! -f /etc/pki/ocserv/private/ca.key;then
 mkdir -p /etc/pki/ocserv/private
-certtool --generate-privkey --outfile /etc/pki/ocserv/private/ca.key >/dev/null 2>&1
+certtool --generate-privkey --key-type=$KEY_TYPE --outfile /etc/pki/ocserv/private/ca.key >/dev/null 2>&1
 echo "cn=`hostname -f` CA" >/etc/pki/ocserv/ca.tmpl
 echo "expiration_days=-1" >>/etc/pki/ocserv/ca.tmpl
 echo "serial=1" >>/etc/pki/ocserv/ca.tmpl
@@ -17,7 +33,7 @@ fi
 
 #generate server certificate/key
 if test ! -f /etc/pki/ocserv/private/server.key;then
-certtool --generate-privkey --outfile /etc/pki/ocserv/private/server.key >/dev/null 2>&1
+certtool --generate-privkey --key-type=$KEY_TYPE --outfile /etc/pki/ocserv/private/server.key >/dev/null 2>&1
 echo "cn=`hostname -f`" >/etc/pki/ocserv/server.tmpl
 echo "serial=2" >>/etc/pki/ocserv/server.tmpl
 echo "expiration_days=-1" >>/etc/pki/ocserv/server.tmpl


### PR DESCRIPTION
Update ocserv-genkey
    
    OCServ genkey is a good tool in OCServ

    The default key type of certtool is rsa, but rsa may not be a good choice

    I tried to add a logic to the ocserv genkey. The key type can be determined according to the parameters. If there is no input parameter, it will be generated according to the default rsa, which does not conflict with the previous use logic.

    After installing OCSERV, I can directly run `ocserv-genkey ecdsa` to generate ecdsa based certificates.